### PR TITLE
Escape custom select in count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Fix checking if the next page exists when a custom select is given #12
+
 ## [0.2.1] - 2020-05-13
 
 ### Fixed

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -60,7 +60,8 @@ module CursorPager
       @next_page ||= if before_limit_value.present?
                        true
                      elsif first
-                       sliced_relation.limit(first + 1).count == first + 1
+                       sliced_relation.unscope(:select).select(1)
+                         .limit(first + 1).count == first + 1
                      else
                        false
                      end

--- a/spec/cursor_pager/page_spec.rb
+++ b/spec/cursor_pager/page_spec.rb
@@ -132,6 +132,13 @@ RSpec.describe CursorPager::Page do
 
         expect(page.next_page?).to be(false)
       end
+
+      it "doesn't crash when a custom select is given" do
+        page = described_class.new(User.select("*"), first: 2)
+        3.times { User.create }
+
+        expect(page.next_page?).to be(true)
+      end
     end
 
     it "returns true when given a `before` cursor" do


### PR DESCRIPTION
Currently when we provide some custom select to the activerecord relation. `next_page?` is raising error during count query. This PR is fixing that by replacing the original select with just `1`