### PR TITLE
Fix using before and after cursor with preloaded associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+* Fix using before and after cursor with preloaded associations #13
 
 ## [0.2.2] - 2020-09-29
 

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -159,6 +159,7 @@ module CursorPager
       id = encoder.decode(cursor)
 
       selects = order_values.map(&:select_string)
+      ordered_relation.preload_values = []
       ordered_relation.unscope(:includes).where(id: id).select(selects).first
     end
   end

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -162,6 +162,7 @@ module CursorPager
       ordered_relation_copy = ordered_relation.dup
 
       ordered_relation_copy.preload_values = []
+      ordered_relation_copy.eager_load_values = []
       ordered_relation_copy
         .unscope(:includes).where(id: id).select(selects).first
     end

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -159,8 +159,11 @@ module CursorPager
       id = encoder.decode(cursor)
 
       selects = order_values.map(&:select_string)
-      ordered_relation.preload_values = []
-      ordered_relation.unscope(:includes).where(id: id).select(selects).first
+      ordered_relation_copy = ordered_relation.dup
+
+      ordered_relation_copy.preload_values = []
+      ordered_relation_copy
+        .unscope(:includes).where(id: id).select(selects).first
     end
   end
 end

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -148,14 +148,18 @@ module CursorPager
     end
 
     def limit_value_for(cursor)
-      id = encoder.decode(cursor)
-
-      selects = order_values.map(&:select_string)
-      item = ordered_relation.where(id: id).select(selects).first
+      item = limit_item_for(cursor)
 
       raise CursorNotFoundError, cursor if item.blank?
 
       order_values.map { |value| item[value.select_alias] }
+    end
+
+    def limit_item_for(cursor)
+      id = encoder.decode(cursor)
+
+      selects = order_values.map(&:select_string)
+      ordered_relation.unscope(:includes).where(id: id).select(selects).first
     end
   end
 end

--- a/spec/cursor_pager/page_records_spec.rb
+++ b/spec/cursor_pager/page_records_spec.rb
@@ -341,8 +341,9 @@ RSpec.describe CursorPager::Page do
     end
 
     context "when some associations are preloaded" do
+      let(:user) { User.create }
+
       context "when no cursor specified" do
-        let(:user) { User.create }
         let!(:book) { Book.create(user: user) }
 
         let(:relation) { Book.preload(:user).all }
@@ -353,7 +354,6 @@ RSpec.describe CursorPager::Page do
       end
 
       context "when the after cursor is specified" do
-        let(:user) { User.create }
         let!(:book1) { Book.create(user: user, id: 1) }
         let!(:book2) { Book.create(user: user, id: 2) }
 
@@ -366,7 +366,6 @@ RSpec.describe CursorPager::Page do
       end
 
       context "when the before cursor is specified" do
-        let(:user) { User.create }
         let!(:book1) { Book.create(user: user, id: 1) }
         let!(:book2) { Book.create(user: user, id: 2) }
 
@@ -380,8 +379,9 @@ RSpec.describe CursorPager::Page do
     end
 
     context "when some associations are eager loaded" do
+      let(:user) { User.create }
+
       context "when no cursor specified" do
-        let(:user) { User.create }
         let!(:book) { Book.create(user: user) }
 
         let(:relation) { Book.eager_load(:user).all }
@@ -392,7 +392,6 @@ RSpec.describe CursorPager::Page do
       end
 
       context "when the after cursor is specified" do
-        let(:user) { User.create }
         let!(:book1) { Book.create(user: user, id: 1) }
         let!(:book2) { Book.create(user: user, id: 2) }
 
@@ -405,7 +404,6 @@ RSpec.describe CursorPager::Page do
       end
 
       context "when the before cursor is specified" do
-        let(:user) { User.create }
         let!(:book1) { Book.create(user: user, id: 1) }
         let!(:book2) { Book.create(user: user, id: 2) }
 
@@ -419,8 +417,9 @@ RSpec.describe CursorPager::Page do
     end
 
     context "when some associations are included" do
+      let(:user) { User.create }
+
       context "when no cursor specified" do
-        let(:user) { User.create }
         let!(:book) { Book.create(user: user) }
 
         let(:relation) { Book.includes(:user).all }
@@ -431,7 +430,6 @@ RSpec.describe CursorPager::Page do
       end
 
       context "when the after cursor is specified" do
-        let(:user) { User.create }
         let!(:book1) { Book.create(user: user, id: 1) }
         let!(:book2) { Book.create(user: user, id: 2) }
 
@@ -444,7 +442,6 @@ RSpec.describe CursorPager::Page do
       end
 
       context "when the before cursor is specified" do
-        let(:user) { User.create }
         let!(:book1) { Book.create(user: user, id: 1) }
         let!(:book2) { Book.create(user: user, id: 2) }
 

--- a/spec/cursor_pager/page_records_spec.rb
+++ b/spec/cursor_pager/page_records_spec.rb
@@ -339,5 +339,122 @@ RSpec.describe CursorPager::Page do
         include_examples "works with first/last/before/after arguments"
       end
     end
+
+    context "when some associations are preloaded" do
+      context "when no cursor specified" do
+        let(:user) { User.create }
+        let!(:book) { Book.create(user: user) }
+
+        let(:relation) { Book.preload(:user).all }
+
+        it "it correctly preloads assosiations" do
+          expect(subject.records.first.association(:user).loaded?).to eq(true)
+        end
+      end
+
+      context "when the after cursor is specified" do
+        let(:user) { User.create }
+        let!(:book1) { Book.create(user: user, id: 1) }
+        let!(:book2) { Book.create(user: user, id: 2) }
+
+        let(:after_cursor) { described_class.new(Book.all).cursor_for(book1) }
+        let(:relation) { Book.preload(:user).all }
+
+        it "it correctly preloads assosiations" do
+          expect(subject.records.first.association(:user).loaded?).to eq(true)
+        end
+      end
+
+      context "when the before cursor is specified" do
+        let(:user) { User.create }
+        let!(:book1) { Book.create(user: user, id: 1) }
+        let!(:book2) { Book.create(user: user, id: 2) }
+
+        let(:before_cursor) { described_class.new(Book.all).cursor_for(book2) }
+        let(:relation) { Book.preload(:user).all }
+
+        it "it correctly preloads assosiations" do
+          expect(subject.records.first.association(:user).loaded?).to eq(true)
+        end
+      end
+    end
+
+    context "when some associations are eager loaded" do
+      context "when no cursor specified" do
+        let(:user) { User.create }
+        let!(:book) { Book.create(user: user) }
+
+        let(:relation) { Book.eager_load(:user).all }
+
+        it "it correctly preloads assosiations" do
+          expect(subject.records.first.association(:user).loaded?).to eq(true)
+        end
+      end
+
+      context "when the after cursor is specified" do
+        let(:user) { User.create }
+        let!(:book1) { Book.create(user: user, id: 1) }
+        let!(:book2) { Book.create(user: user, id: 2) }
+
+        let(:after_cursor) { described_class.new(Book.all).cursor_for(book1) }
+        let(:relation) { Book.eager_load(:user).all }
+
+        it "it correctly preloads assosiations" do
+          expect(subject.records.first.association(:user).loaded?).to eq(true)
+        end
+      end
+
+      context "when the before cursor is specified" do
+        let(:user) { User.create }
+        let!(:book1) { Book.create(user: user, id: 1) }
+        let!(:book2) { Book.create(user: user, id: 2) }
+
+        let(:before_cursor) { described_class.new(Book.all).cursor_for(book2) }
+        let(:relation) { Book.eager_load(:user).all }
+
+        it "it correctly preloads assosiations" do
+          expect(subject.records.first.association(:user).loaded?).to eq(true)
+        end
+      end
+    end
+
+    context "when some associations are included" do
+      context "when no cursor specified" do
+        let(:user) { User.create }
+        let!(:book) { Book.create(user: user) }
+
+        let(:relation) { Book.includes(:user).all }
+
+        it "it correctly preloads assosiations" do
+          expect(subject.records.first.association(:user).loaded?).to eq(true)
+        end
+      end
+
+      context "when the after cursor is specified" do
+        let(:user) { User.create }
+        let!(:book1) { Book.create(user: user, id: 1) }
+        let!(:book2) { Book.create(user: user, id: 2) }
+
+        let(:after_cursor) { described_class.new(Book.all).cursor_for(book1) }
+        let(:relation) { Book.includes(:user).all }
+
+        it "it correctly preloads assosiations" do
+          expect(subject.records.first.association(:user).loaded?).to eq(true)
+        end
+      end
+
+      context "when the before cursor is specified" do
+        let(:user) { User.create }
+        let!(:book1) { Book.create(user: user, id: 1) }
+        let!(:book2) { Book.create(user: user, id: 2) }
+
+        let(:before_cursor) { described_class.new(Book.all).cursor_for(book2) }
+        let(:relation) { Book.includes(:user).all }
+
+        it "it correctly preloads assosiations" do
+          expect(subject.records.first.association(:user).loaded?).to eq(true)
+        end
+      end
+    end
   end
 end

--- a/spec/cursor_pager/page_spec.rb
+++ b/spec/cursor_pager/page_spec.rb
@@ -111,6 +111,16 @@ RSpec.describe CursorPager::Page do
     end
 
     it "returns true when given a `after` cursor and "\
+      "relation preloads other relation" do
+      books = 2.times.map { Book.create }
+      page = described_class.new(
+        Book.preload(:user).all, after: encode_cursor(books.first)
+      )
+
+      expect(page.previous_page?).to be(true)
+    end
+
+    it "returns true when given a `after` cursor and "\
       "relation includes other relation" do
       books = 2.times.map { Book.create }
       page = described_class.new(
@@ -154,6 +164,16 @@ RSpec.describe CursorPager::Page do
     it "returns true when given a `before` cursor" do
       users = 2.times.map { User.create }
       page = described_class.new(User.all, before: encode_cursor(users.last))
+
+      expect(page.next_page?).to be(true)
+    end
+
+    it "returns true when given a `before` cursor and "\
+      "relation preloads other relation" do
+      books = 2.times.map { Book.create }
+      page = described_class.new(
+        Book.preload(:user).all, before: encode_cursor(books.last)
+      )
 
       expect(page.next_page?).to be(true)
     end

--- a/spec/cursor_pager/page_spec.rb
+++ b/spec/cursor_pager/page_spec.rb
@@ -110,26 +110,6 @@ RSpec.describe CursorPager::Page do
       expect(page.previous_page?).to be(true)
     end
 
-    it "returns true when given a `after` cursor and "\
-      "relation preloads other relation" do
-      books = 2.times.map { Book.create }
-      page = described_class.new(
-        Book.preload(:user).all, after: encode_cursor(books.first)
-      )
-
-      expect(page.previous_page?).to be(true)
-    end
-
-    it "returns true when given a `after` cursor and "\
-      "relation includes other relation" do
-      books = 2.times.map { Book.create }
-      page = described_class.new(
-        Book.includes(:user).all, after: encode_cursor(books.first)
-      )
-
-      expect(page.previous_page?).to be(true)
-    end
-
     it "returns false when given no arguments" do
       page = described_class.new(User.all)
 
@@ -164,26 +144,6 @@ RSpec.describe CursorPager::Page do
     it "returns true when given a `before` cursor" do
       users = 2.times.map { User.create }
       page = described_class.new(User.all, before: encode_cursor(users.last))
-
-      expect(page.next_page?).to be(true)
-    end
-
-    it "returns true when given a `before` cursor and "\
-      "relation preloads other relation" do
-      books = 2.times.map { Book.create }
-      page = described_class.new(
-        Book.preload(:user).all, before: encode_cursor(books.last)
-      )
-
-      expect(page.next_page?).to be(true)
-    end
-
-    it "returns true when given a `before` cursor and "\
-      "relation includes other relation" do
-      books = 2.times.map { Book.create }
-      page = described_class.new(
-        Book.includes(:user).all, before: encode_cursor(books.last)
-      )
 
       expect(page.next_page?).to be(true)
     end

--- a/spec/cursor_pager/page_spec.rb
+++ b/spec/cursor_pager/page_spec.rb
@@ -110,6 +110,16 @@ RSpec.describe CursorPager::Page do
       expect(page.previous_page?).to be(true)
     end
 
+    it "returns true when given a `after` cursor and "\
+      "relation includes other relation" do
+      books = 2.times.map { Book.create }
+      page = described_class.new(
+        Book.includes(:user).all, after: encode_cursor(books.first)
+      )
+
+      expect(page.previous_page?).to be(true)
+    end
+
     it "returns false when given no arguments" do
       page = described_class.new(User.all)
 
@@ -144,6 +154,16 @@ RSpec.describe CursorPager::Page do
     it "returns true when given a `before` cursor" do
       users = 2.times.map { User.create }
       page = described_class.new(User.all, before: encode_cursor(users.last))
+
+      expect(page.next_page?).to be(true)
+    end
+
+    it "returns true when given a `before` cursor and "\
+      "relation includes other relation" do
+      books = 2.times.map { Book.create }
+      page = described_class.new(
+        Book.includes(:user).all, before: encode_cursor(books.last)
+      )
 
       expect(page.next_page?).to be(true)
     end


### PR DESCRIPTION
When ActiveRecord relation includes another `belongs_to` reaction - rails `select` method is trying to select given query on all the included tables. In our case during before or after item calculations - this leads to database error - “no column found”. Since we don’t need the included tables during before and after item calculations we can get rid of the includes there.