### PR TITLE
Fix next_page?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fix `Cursor::Page#next_page?` when given a grouped relation #15
+
 ## [0.2.3] - 2020-11-23
 
 ### Fixed

--- a/lib/cursor_pager/page.rb
+++ b/lib/cursor_pager/page.rb
@@ -60,8 +60,7 @@ module CursorPager
       @next_page ||= if before_limit_value.present?
                        true
                      elsif first
-                       sliced_relation.unscope(:select).select(1)
-                         .limit(first + 1).count == first + 1
+                       sliced_relation.offset(first).exists?
                      else
                        false
                      end

--- a/spec/cursor_pager/page_spec.rb
+++ b/spec/cursor_pager/page_spec.rb
@@ -139,6 +139,22 @@ RSpec.describe CursorPager::Page do
 
         expect(page.next_page?).to be(true)
       end
+
+      context "when given grouped relation" do
+        it "returns true" do
+          2.times.map { User.create }
+          page = described_class.new(User.all.group(:id), first: 1)
+
+          expect(page.next_page?).to be(true)
+        end
+
+        it "returns false" do
+          2.times.map { User.create }
+          page = described_class.new(User.all.group(:id), first: 2)
+
+          expect(page.next_page?).to be(false)
+        end
+      end
     end
 
     it "returns true when given a `before` cursor" do


### PR DESCRIPTION
Why:

When given a relation is grouped, the `count` would return an aggregation hash where key is `id` while the value is the `count`. The method would ends up always returning `false`.